### PR TITLE
Add unit tests for org.xujin.moss.client.endpoint.dependency.util.PomUtil

### DIFF
--- a/moss-client/moss-client-common/pom.xml
+++ b/moss-client/moss-client-common/pom.xml
@@ -70,6 +70,13 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.9.9</version>
         </dependency>
+        
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/moss-client/moss-client-common/src/test/java/org/xujin/moss/client/endpoint/dependency/util/PomUtilTest.java
+++ b/moss-client/moss-client-common/src/test/java/org/xujin/moss/client/endpoint/dependency/util/PomUtilTest.java
@@ -1,0 +1,22 @@
+package org.xujin.moss.client.endpoint.dependency.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PomUtilTest {
+    @Test
+    public void testGetArtifactIdAndVersion() {
+        Assert.assertArrayEquals(
+            new String[] {"", "٢９٢٢٢٢٢٢٢٢٢٢٢٢٢٢"},
+            PomUtil.getArtifactIdAndVersion("-٢９٢٢٢٢٢٢٢٢٢٢٢٢٢٢"));
+        Assert.assertArrayEquals(
+            new String[] {"", "9-"},
+            PomUtil.getArtifactIdAndVersion("-9-"));
+        Assert.assertArrayEquals(
+            new String[] {"-", "9"},
+            PomUtil.getArtifactIdAndVersion("--9"));
+        Assert.assertNull(PomUtil.getArtifactIdAndVersion("3"));
+        Assert.assertNull(PomUtil.getArtifactIdAndVersion("-"));
+        Assert.assertNull(PomUtil.getArtifactIdAndVersion("--"));
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `org.xujin.moss.client.endpoint.dependency.util.PomUtil` is not fully tested.

I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.